### PR TITLE
fix(plugin-gitlab): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/gitlab/issues/package-info.java
+++ b/src/main/java/io/kestra/plugin/gitlab/issues/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Issues",
+    title = "GitLab Issues",
     description = "This sub-group of plugins contains tasks for using GitLab.\nSet the GitLab host name, project ID, and access token to file issues with title/description, add comments or updates, and list or retrieve issue details for triage workflows.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,

--- a/src/main/java/io/kestra/plugin/gitlab/mergerequests/package-info.java
+++ b/src/main/java/io/kestra/plugin/gitlab/mergerequests/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Merge Requests",
+    title = "GitLab Merge Requests",
     description = "Tasks that create, update, and fetch GitLab Merge Requests.\nSet the GitLab host name, project ID, and access token to handle Merge Requests.",
     categories = {
         PluginSubGroup.PluginCategory.INFRASTRUCTURE,


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge