### PR TITLE
docs: state connection properties per task instead of plugin defaults

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.gitlab.md
+++ b/src/main/resources/doc/io.kestra.plugin.gitlab.md
@@ -4,7 +4,7 @@ Create issues and merge requests, and search issues in GitLab from Kestra flows.
 
 ## Authentication
 
-Set `token` to a GitLab personal, project, or group access token with scopes covering the operations you need. `url` defaults to `https://gitlab.com` — set it to your instance URL for self-hosted GitLab. Set `projectId` to the numeric project ID or URL-encoded project path. Store `token` in a [secret](https://kestra.io/docs/concepts/secret) and apply all three globally with [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults).
+Set `token` to a GitLab personal, project, or group access token with scopes covering the operations you need. `url` defaults to `https://gitlab.com` — set it to your instance URL for self-hosted GitLab. Set `projectId` to the numeric project ID or URL-encoded project path. Store `token` in a [secret](https://kestra.io/docs/concepts/secret) and set all three on each task.
 
 ## Tasks
 


### PR DESCRIPTION
Removes references to `pluginDefaults`, which was removed in the latest Kestra
release, from this plugin's documentation. Connection properties are now stated
on each task.

Part of a sweep across the plugin repositories: the docs link to
`kestra.io/docs/workflow-components/plugin-defaults` and the surrounding prose
would otherwise point users at a removed feature and a dead docs page.